### PR TITLE
Añadir configuración CI/CD para la rama develop

### DIFF
--- a/.github/workflows/develop_ci_cd.yml
+++ b/.github/workflows/develop_ci_cd.yml
@@ -1,0 +1,53 @@
+name: Develop CI/CD
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  develop_ci_cd:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Checkout del repositorio
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # 2. Configurar Python
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+
+      # 3. Instalar dependencias
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # 4. Ejecutar pruebas
+      - name: Run tests
+        run: |
+          python manage.py test
+
+      # 5. Construir la imagen Docker
+      - name: Build Docker image
+        run: |
+          docker build -t ${{secrets.DOCKER_USER}}/criticroute_api:develop .
+
+      # Iniciar sesión en Docker Hub
+      - name: Login to Docker Hub
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+
+      # 7. Subir la imagen Docker
+      - name: Push Docker image
+        run: |
+          docker push ${{secrets.DOCKER_USER}}/criticroute_api:develop


### PR DESCRIPTION
Qué se hizo:
- Se añadió el archivo .github/workflows/develop_ci_cd.yml.
- Configuración para ejecutar pruebas y generar un Docker.

Por qué se hizo:
- Para automatizar el proceso de integración y despliegue continuo en la rama develop.