### PR TITLE
Ejecutar flujo de trabajo solo con tags, eliminando trigger para pull requests

### DIFF
--- a/.github/workflows/release_ci_cd.yml
+++ b/.github/workflows/release_ci_cd.yml
@@ -6,9 +6,6 @@ on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - release/*
 
 jobs:
   release_ci_cd:


### PR DESCRIPTION
### **¿Qué se hizo?**

Se ha modificado el flujo de trabajo de CI/CD para que solo se ejecute cuando se realice un *push* de un tag (por ejemplo, 'v1.0.0'), se ha eliminado la configuración que activaba el flujo de trabajo en base a *pull requests*, garantizando que el pipeline solo se ejecute en versiones etiquetadas del proyecto.

### **¿Por qué se hizo?**

Este cambio mejora el proceso de CI/CD al limitar su ejecución únicamente a los momentos en que se despliegan nuevas versiones mediante tags, de esta manera, se optimiza el pipeline, enfocándose en versiones etiquetadas y evitando ejecuciones innecesarias por *pull requests*.

