### PR TITLE
Desactivación de CSRF y habilitación de CORS

### DIFF
--- a/CriticRoute_API/settings.py
+++ b/CriticRoute_API/settings.py
@@ -36,6 +36,7 @@ ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS').split(',')
 # Application definition
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -49,7 +50,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -153,3 +154,30 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(days=4),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=3),
 }
+
+CORS_ALLOW_CREDENTIALS = False
+
+CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_SECURE = False
+
+CSRF_TRUSTED_ORIGINS = ['http://localhost:4200']
+
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:4200'
+]
+
+CORS_ALLOW_METHODS = [
+    'DELETE',
+    'GET',
+    'OPTIONS',
+    'PATCH',
+    'POST',
+    'PUT',
+]
+
+CORS_ALLOW_HEADERS = [
+    'Authorization',
+    'Content-Type',
+    'X-CSRFToken',
+    'X-Requested-With',
+]

--- a/CriticRoute_API/settings.py
+++ b/CriticRoute_API/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -155,9 +156,8 @@ SIMPLE_JWT = {
     'REFRESH_TOKEN_LIFETIME': timedelta(days=3),
 }
 
-CORS_ALLOW_CREDENTIALS = False
+CORS_ALLOW_CREDENTIALS = True
 
-CSRF_COOKIE_HTTPONLY = False
 CSRF_COOKIE_SECURE = False
 
 CSRF_TRUSTED_ORIGINS = ['http://localhost:4200']

--- a/CriticRoute_API/src/infraestructure/delivery/views/views.py
+++ b/CriticRoute_API/src/infraestructure/delivery/views/views.py
@@ -1,7 +1,7 @@
 import base64
 
 from django.middleware.csrf import get_token
-from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -19,7 +19,7 @@ from CriticRoute_API.src.infraestructure.delivery.dto.response.auth_token import
 from CriticRoute_API.src.infraestructure.delivery.dto.response.dtos import ProyectoDTOSerializer
 
 
-@ensure_csrf_cookie
+@csrf_exempt
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def post_crear_usuario(request, verificar_usuario, crear_cuenta, mapper_dto):
@@ -66,7 +66,7 @@ def post_crear_usuario(request, verificar_usuario, crear_cuenta, mapper_dto):
     return response
 
 
-@ensure_csrf_cookie
+@csrf_exempt
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def post_nuevo_proyecto(request, generar_grafo: GenerarCPM, guardar_grafo: GuardarGrafoCPM):


### PR DESCRIPTION
- Se desactivó temporalmente la protección CSRF en el backend para permitir pruebas de integración con el frontend.
- Se configuró el middleware de CORS en Django para habilitar solicitudes desde http://localhost:4200.
- Se habilitó el uso de credenciales (cookies) en CORS para manejar autenticación y CSRF.
- Estos cambios están destinados exclusivamente para pruebas en el entorno de desarrollo y deben ser revertidos antes del despliegue en producción.
